### PR TITLE
Add copy without querystring and copy without fragments

### DIFF
--- a/background.js
+++ b/background.js
@@ -33,9 +33,25 @@ function copyToClipboard(text) {
   document.execCommand("copy");
 }
 
+function splitUrl(url, sep = "?") {
+  return url.split(sep).at(0);
+}
+
 browser.menus.create({
   id: "copy-tab-url",
-  title: "Copy Tab URL",
+  title: "Complete",
+  contexts: ["tab"]
+}, onCreated);
+
+browser.menus.create({
+  id: "copy-tab-url-no-querystring",
+  title: "Without Querystring",
+  contexts: ["tab"]
+}, onCreated);
+
+browser.menus.create({
+  id: "copy-tab-url-no-fragments",
+  title: "Without Fragments",
   contexts: ["tab"]
 }, onCreated);
 
@@ -43,7 +59,15 @@ browser.menus.create({
  * Click event listener
 */
 browser.menus.onClicked.addListener((info, tab) => {
-  if (info.menuItemId === "copy-tab-url") {
-    copyToClipboard(tab.url);
+  switch (info.menuItemId) {
+    case "copy-tab-url":
+      copyToClipboard(tab.url);
+      break;
+    case "copy-tab-url-no-querystring":
+      copyToClipboard(splitUrl(tab.url));
+      break;
+    case "copy-tab-url-no-fragments":
+      copyToClipboard(splitUrl(tab.url, "#"));
+      break;
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Copy Tab Link",
     "description": "Adds an entry to a tab's context menu to copy the tab's URL to the clipboard.",
-    "version": "0.1.0",
+    "version": "0.1.1",
 
     "background": {
         "scripts": [


### PR DESCRIPTION
Hi, 

I added an option to copy the URL without the querystring and without fragments. Currently, the code is quite naïve and it just splits the string at the first instance of `?` (for the querystring) or `#` (for the fragments).

Not sure if this is something you might be interested in, but please let me know. 